### PR TITLE
Fix/#7 log date type convert

### DIFF
--- a/Sources/SQServiceStorage/Model/DBTables/YTPlaylistHeadTable.swift
+++ b/Sources/SQServiceStorage/Model/DBTables/YTPlaylistHeadTable.swift
@@ -13,9 +13,10 @@ struct YTPlaylistHeadTable: Codable {
     let title:String
     var channelID: String
     let thumbnailURLString: String
-    let insertedDate:Date
+    let insertedDate: Date
     let isShazamed: Bool
     let playlistType: YTPlaylistTypeDTO.RawValue
+    
     init(id: String,
          originURL: String,
          title: String,
@@ -42,12 +43,13 @@ struct YTPlaylistHeadTable: Codable {
         self.thumbnailURLString = try container.decode(String.self, forKey: .thumbnailURLString)
         let date = try container.decode(String.self, forKey: .insertedDate)
         let dateFormatter = DateFormatter()
-        dateFormatter.dateFormat = "yyyy-MM-dd'T'HH:mm:ssXXX"
-        dateFormatter.timeZone = TimeZone(secondsFromGMT: 0)
-        guard let insertedDate = dateFormatter.date(from: date) else {
-            throw PlaylistCachierError.dateConvertFailed
-        }
+        let customFormat = Date.ISO8601FormatStyle(
+            includingFractionalSeconds: false,
+            timeZone: .autoupdatingCurrent
+        )
+        let insertedDate = try customFormat.parseStrategy.parse(date)
         self.insertedDate = insertedDate
+        
         self.isShazamed = try container.decode(Bool.self, forKey: .isShazamed)
         self.playlistType = try container.decode(YTPlaylistTypeDTO.RawValue.self, forKey: .playlistType)
     }

--- a/Sources/SQServiceStorage/Model/PublicDTOs/YTChannelInfoDTO.swift
+++ b/Sources/SQServiceStorage/Model/PublicDTOs/YTChannelInfoDTO.swift
@@ -11,7 +11,7 @@ public struct YTChannelInfoDTO: Codable {
     public let id: String
     public let name: String
     public var subscribers: Int = 0
-    public var thumbnailURLString: String = ""
+    public var thumbnailURLString: String
     
     public init(
         id: String,
@@ -21,6 +21,8 @@ public struct YTChannelInfoDTO: Codable {
     ) {
         self.id = id
         self.name = name
+        self.subscribers = subscribers
+        self.thumbnailURLString = thumbnailURLString
     }
     
 }

--- a/Sources/SQServiceStorage/Model/PublicDTOs/YTPlaylistDTO.swift
+++ b/Sources/SQServiceStorage/Model/PublicDTOs/YTPlaylistDTO.swift
@@ -13,8 +13,9 @@ public struct YTPlaylistDTO {
     public let body: YTPlaylistBodyDTO
     
     /// 메타데이터와 PlaylistData 둘 존재하는 경우 사용합니다.
-    public init(head: YTPlaylistHeadDTO,
-                body: YTPlaylistBodyDTO
+    public init(
+        head: YTPlaylistHeadDTO,
+        body: YTPlaylistBodyDTO
     ) {
         self.head = head
         self.body = body

--- a/Sources/SQServiceStorage/SQSupabaseQuerier/3. SqoopsQuerier.swift
+++ b/Sources/SQServiceStorage/SQSupabaseQuerier/3. SqoopsQuerier.swift
@@ -25,8 +25,8 @@ public struct SqoopsQuerier {
         let logRequestDTO = SqoopsLogRequest(id: playlistID, date: date, locale: locale, channelID: channelID)
         let logURLRequest = SqoopsEndPoint.insert_log(logRequestDTO)
             .getURLRequest(baseUrl: self.supabaseURL, supabaseKey: self.supabaseKey)
-        guard let (_ , response) = try? await URLSession.shared.data(for: logURLRequest),
-              (response as? HTTPURLResponse)?.statusCode == 200 else {
+        let (data, response) = try await URLSession.shared.data(for: logURLRequest)
+        guard (response as? HTTPURLResponse)?.statusCode == 200 else {
             throw NetworkingError.DataConvertFailed
         }
     }

--- a/Sources/SQServiceStorage/SQSupabaseQuerier/Model/SqoopsLogRequest.swift
+++ b/Sources/SQServiceStorage/SQSupabaseQuerier/Model/SqoopsLogRequest.swift
@@ -9,7 +9,21 @@ import Foundation
 
 struct SqoopsLogRequest: Encodable {
     let id: String
-    let date: Date
+    let date: String
     let locale: String
     let channelID: String
+    
+    init(
+        id: String,
+        date: Date,
+        locale: String,
+        channelID: String
+    ) {
+        self.id = id
+        self.date = date.ISO8601Format(.iso8601(timeZone: .autoupdatingCurrent, includingFractionalSeconds: false))
+        self.locale = locale
+        self.channelID = channelID
+    }
 }
+
+

--- a/Tests/QuerierTests/ChannelsAPI.swift
+++ b/Tests/QuerierTests/ChannelsAPI.swift
@@ -20,5 +20,6 @@ struct ChannelsAPITest {
         let res = try await querier.getPlaylists(channelID: "UCjmZi4wQOrIKhDBn4nDyPLw", limitCount: 1)
         print(res)
     }
+    
 }
 

--- a/Tests/QuerierTests/SqoopsAPI.swift
+++ b/Tests/QuerierTests/SqoopsAPI.swift
@@ -6,3 +6,20 @@
 //
 
 import Foundation
+import Testing
+@testable import SQServiceStorage
+
+@Suite("SqoopsAPI")
+struct SqoopsAPI {
+    let sqoopsQuerier = SqoopsQuerier(
+        supabaseURL: URL(string: SUPABASE_URL)!,
+        supabaseKey: ANON_KEY
+    )
+    @Test func logAppend() async throws {
+        do {
+            try await sqoopsQuerier.appendPlaylistLog(playlistID: "Test", channelID: "Test")
+        } catch {
+            print(error)
+        }
+    }
+}


### PR DESCRIPTION
# 🤷🏻‍♂️ 문제 상황
> 발생한 문제 상황에 대한 설명을 적어주세요.

- 스쿱 로그를 추가하면 1970년대로 날짜가 추가되는 문제가 발생했습니다.

# 🚀 문제 해결 
> 문제 해결한 방식을 적어주세요.

기존 SqoopLogRequest에서 Swift의 Date 타입으로 Log 값을 정의하고 JSON으로 변환해서 Edge Function에 전송했습니다.
이에 따라 Edge Function에서 json 디코딩 이후 유닉스 타임스탬프 값 -> 숫자값... 으로 변환했습니다.
문제는 이 타입을 타입스크립트의 Date 타입으로 변환하는데 형식이 맞지 않았고 이에 따른 문제가 발생했습니다.

> 해결 방법

SqoopLogRequest의 date 타입의 값을 바꿉니다.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- New Features
  - Added Charts, Channels, and Sqoops queriers for recent/most playlists/channels, channel playlists, and logging.
  - New lookups: total playlists count and Shazam status.
- Refactor
  - Unified generic response models; streamlined playlist retrieval; standardized ISO8601 date parsing.
  - Removed legacy ID-list and log-append methods from the previous API.
- Documentation
  - Expanded README with package overview, setup, and high-level API; added migration histories.
- Tests
  - Added tests covering Charts, Channels, and Sqoops queriers.
- Chores
  - Broadened .gitignore pattern for API keys.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->